### PR TITLE
Refactor parsing to improve immutability of SectionMarker

### DIFF
--- a/update_repo.py
+++ b/update_repo.py
@@ -60,17 +60,18 @@ def neovim_config() -> None:
         if operation == "init_vim_no_plug":
             data: list[str] = read_lines(paths.src)
             filtered_data: list[str] = []
+            is_within_section = False
 
             for current_line in data:
                 if NEOVIM_MARKERS.start_marker in current_line:
-                    NEOVIM_MARKERS.is_within_section = True
+                    is_within_section = True
                 if (
                     NEOVIM_MARKERS.end_marker in current_line
-                    and NEOVIM_MARKERS.is_within_section
+                    and is_within_section
                 ):
-                    NEOVIM_MARKERS.is_within_section = False
+                    is_within_section = False
                     break
-                if NEOVIM_MARKERS.is_within_section:
+                if is_within_section:
                     filtered_data.append(current_line)
             write_file(paths.dest, "".join(filtered_data))
         else:
@@ -133,6 +134,8 @@ def zsh_config() -> None:
     for file_operation, file_paths in ZSH_CONFIG_PATHS.items():
         data: list[str] = read_lines(file_paths.src)
         output_data: list[str] = []
+        is_within_alias_section = False
+        is_within_ls_colors_section = False
         line_number = 0
 
         while line_number < len(data):
@@ -153,31 +156,28 @@ def zsh_config() -> None:
                 continue
 
             if ZSH_ALIAS_MARKERS.start_marker in current_line:
-                ZSH_ALIAS_MARKERS.is_within_section = True
+                is_within_alias_section = True
                 output_data.append(ZENSICAL_USER_CONFIG_MARKERS.start_marker)
             elif ZSH_LS_COLORS_MARKERS.start_marker in current_line:
-                ZSH_LS_COLORS_MARKERS.is_within_section = True
+                is_within_ls_colors_section = True
                 output_data.append(ZENSICAL_LS_COLORS_MARKERS.start_marker)
 
             if (
                 ZSH_ALIAS_MARKERS.end_marker in current_line
-                and ZSH_ALIAS_MARKERS.is_within_section
+                and is_within_alias_section
             ):
-                ZSH_ALIAS_MARKERS.is_within_section = False
+                is_within_alias_section = False
                 output_data.append(ZENSICAL_USER_CONFIG_MARKERS.end_marker)
             elif (
                 ZSH_LS_COLORS_MARKERS.end_marker in current_line
-                and ZSH_LS_COLORS_MARKERS.is_within_section
+                and is_within_ls_colors_section
             ):
-                ZSH_LS_COLORS_MARKERS.is_within_section = False
+                is_within_ls_colors_section = False
                 if ZSH_LS_COLORS_MARKERS.hard_coded_inclusion:
                     output_data.extend(ZSH_LS_COLORS_MARKERS.hard_coded_inclusion)
                 output_data.append(ZENSICAL_LS_COLORS_MARKERS.end_marker)
 
-            if (
-                ZSH_ALIAS_MARKERS.is_within_section
-                or ZSH_LS_COLORS_MARKERS.is_within_section
-            ):
+            if is_within_alias_section or is_within_ls_colors_section:
                 output_data.append(current_line)
 
             line_number += 1

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -14,21 +14,20 @@ modified when upstream dotfile structures change.
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Final, Tuple
+from typing import Final
 
 
-@dataclass
+@dataclass(frozen=True)
 class ConfigPath:
     src: Path
     dest: Path
 
 
-@dataclass
+@dataclass(frozen=True)
 class SectionMarker:
     start_marker: str
     end_marker: str
-    hard_coded_inclusion: Tuple[str, ...] | None = None
-    is_within_section: bool = False
+    hard_coded_inclusion: tuple[str, ...] | None = None
 
 
 # Maps Neovim config variants to their source and destination paths.


### PR DESCRIPTION
This pull request refactors how section markers are tracked in both the `neovim_config` and `zsh_config` functions, removing mutable state from the `SectionMarker` dataclass and instead using local variables within the functions. This change improves code clarity and thread safety by ensuring that section state is not shared across function calls or instances.

**Refactoring of section marker state:**

* The `is_within_section` and related state are now tracked using local variables (`is_within_section`, `is_within_alias_section`, `is_within_ls_colors_section`) within the `neovim_config` and `zsh_config` functions, rather than as mutable attributes on the `SectionMarker` dataclass. [[1]](diffhunk://#diff-58fd0228aca4f77501d26bb6416123430ee4f4e04770b0506097ab014233be54R63-R74) [[2]](diffhunk://#diff-58fd0228aca4f77501d26bb6416123430ee4f4e04770b0506097ab014233be54R137-R138) [[3]](diffhunk://#diff-58fd0228aca4f77501d26bb6416123430ee4f4e04770b0506097ab014233be54L156-R180)

**Improvements to data structures:**

* The `SectionMarker` and `ConfigPath` dataclasses in `utils/constants.py` are now frozen (immutable), and the type annotation for `hard_coded_inclusion` is updated to use the standard `tuple` type.Moves 'is_within_section' state from the SectionMarker dataclass to local variables within the parsing functions. This makes SectionMarker and ConfigPath dataclasses frozen, improving immutability and state isolation.